### PR TITLE
Adds the conventional ROOT_DIR for d.rymcg.tech and fixes default URL.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 # Update this to point to your d.ry repo
-ROOT_DIR = ${HOME}/git/d.rymcg.tech
+ROOT_DIR = ${HOME}/git/vendor/enigmacurry/d.rymcg.tech
 include ${ROOT_DIR}/_scripts/Makefile.projects-external
 include ${ROOT_DIR}/_scripts/Makefile.instance
 
 .PHONY: config-hook
 config-hook:
 	@${BIN}/reconfigure ${ENV_FILE} WP_INSTANCE=${instance}
-	@${BIN}/reconfigure_ask ${ENV_FILE} WP_TRAEFIK_HOST "Enter the wp domain name" ${INSTANCE_URL_SUFFIX}.${ROOT_DOMAIN}
+	@${BIN}/reconfigure_ask ${ENV_FILE} WP_TRAEFIK_HOST "Enter the wp domain name" wp${INSTANCE_URL_SUFFIX}.${ROOT_DOMAIN}
 	@${BIN}/reconfigure_password ${ENV_FILE} WP_DB_ROOT_PASSWORD
 	@${BIN}/reconfigure_password ${ENV_FILE} WP_DB_PASSWORD
 


### PR DESCRIPTION
The upstream docs for d.rymcg.tech inform the user to clone to: $HOME/git/vendor/enigmacurry/d.rymcg.tech
This default path is considered to be good enough for all users. I understand some people will still desire to clone this elsewhere, but a standard default path seems like a good idea for new users. (A convenient fix between styles would be to create a symlink to the real directory.)

Fixes the default URL shown by `make config`. The default is `wp${INSTANCE_URL_SUFFIX}.${ROOT_DOMAIN}` which expands to wp.example.com for the default instance, and wp-foo.example.com for the foo instance. Obviously not eveyone wants `wp` in their url, but there should be some kind of default here. This is how its done in the rest of the d.ry apps at least.