### PR TITLE
wp2static

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -15,3 +15,15 @@ TIMEZONE=America/New_York
 ##Allow all access: 0.0.0.0/0
 WP_IP_SOURCERANGE=0.0.0.0/0
 WP_HTTP_AUTH=
+
+## Enable anti-hotlinking of images (or not):
+WP_ANTI_HOTLINK=true
+
+## Extra URLs besides WP_TRAEFIK_HOST to allow hotlinking from:
+## Specify multiple domains separated by commas.
+## (Wildcard domains allowed. Must include port number if not 80/443)
+WP_ANTI_HOTLINK_REFERERS_EXTRA=
+
+## Should clients that *don't* specify the referer be allowed to hotlink?
+## (eg. RSS readers, curl, or copy and pasting into the browser URL bar.)
+WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER=true

--- a/.env-dist
+++ b/.env-dist
@@ -3,9 +3,6 @@ WP_VERSION=6.1.1
 WP_MARIADB_VERSION=10.9
 WP_INSTANCE=
 
-## https://github.com/WP2Static/wp2static/releases
-WP_WP2STATIC_VERSION=7.2
-
 WP_DB_DATABASE=wp
 WP_DB_ROOT_PASSWORD=
 WP_DB_USER=wpuser
@@ -30,3 +27,9 @@ WP_ANTI_HOTLINK_REFERERS_EXTRA=
 ## Should clients that *don't* specify the referer be allowed to hotlink?
 ## (eg. RSS readers, curl, or copy and pasting into the browser URL bar.)
 WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER=true
+
+## https://github.com/WP2Static/wp2static/releases
+WP_WP2STATIC=false
+WP_WP2STATIC_VERSION=7.2
+WP_TRAEFIK_HOST_STATIC=static.d.example.com
+WP_IP_SOURCERANGE_STATIC=0.0.0.0/0

--- a/.env-dist
+++ b/.env-dist
@@ -3,6 +3,9 @@ WP_VERSION=6.1.1
 WP_MARIADB_VERSION=10.9
 WP_INSTANCE=
 
+## https://github.com/WP2Static/wp2static/releases
+WP_WP2STATIC_VERSION=7.2
+
 WP_DB_DATABASE=wp
 WP_DB_ROOT_PASSWORD=
 WP_DB_USER=wpuser

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,20 @@ include ${ROOT_DIR}/_scripts/Makefile.instance
 .PHONY: config-hook
 config-hook:
 	@${BIN}/reconfigure ${ENV_FILE} WP_INSTANCE=${instance}
+	@echo ""
 	@${BIN}/reconfigure_ask ${ENV_FILE} WP_TRAEFIK_HOST "Enter the wp domain name" wp${INSTANCE_URL_SUFFIX}.${ROOT_DOMAIN}
 	@${BIN}/reconfigure_password ${ENV_FILE} WP_DB_ROOT_PASSWORD
 	@${BIN}/reconfigure_password ${ENV_FILE} WP_DB_PASSWORD
+	@${BIN}/reconfigure_htpasswd ${ENV_FILE} WP_HTTP_AUTH default=no
+	@echo ""
 	@${BIN}/confirm $$([[ $$(${BIN}/dotenv -f ${ENV_FILE} get WP_ANTI_HOTLINK) == "true" ]] && echo "yes" || echo "no") "Do you want to enable anti-hotlinking of images" "?" && ${BIN}/reconfigure ${ENV_FILE} WP_ANTI_HOTLINK=true || ${BIN}/reconfigure ${ENV_FILE} WP_ANTI_HOTLINK=false || true
-	[[ $$(${BIN}/dotenv -f ${ENV_FILE} get WP_ANTI_HOTLINK) == "true" ]] && ${BIN}/confirm $$([[ $$(${BIN}/dotenv -f ${ENV_FILE} get WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER) == "true" ]] && echo "yes" || echo "no") "Should a client that sends an empty referer be allowed to view attachments" "?" && ${BIN}/reconfigure ${ENV_FILE} WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER=true || ${BIN}/reconfigure ${ENV_FILE} WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER=false || true
+	@echo ""
+	@[[ $$(${BIN}/dotenv -f ${ENV_FILE} get WP_ANTI_HOTLINK) == "true" ]] && ${BIN}/confirm $$([[ $$(${BIN}/dotenv -f ${ENV_FILE} get WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER) == "true" ]] && echo "yes" || echo "no") "Should a client that sends an empty referer be allowed to view attachments" "?" && ${BIN}/reconfigure ${ENV_FILE} WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER=true || ${BIN}/reconfigure ${ENV_FILE} WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER=false || true
+	@echo ""
+	@${BIN}/confirm $$([[ $$(${BIN}/dotenv -f ${ENV_FILE} get WP_WP2STATIC) == "true" ]] && echo "yes" || echo "no") "Do you want to create a static HTML wordpress export via wp2static" "?" && ${BIN}/reconfigure ${ENV_FILE} WP_WP2STATIC=true || ${BIN}/reconfigure ${ENV_FILE} WP_WP2STATIC=false || true
+	@echo ""
+	@[[ $$(${BIN}/dotenv -f ${ENV_FILE} get WP_WP2STATIC) == "true" ]] && ${BIN}/reconfigure_ask ${ENV_FILE} WP_TRAEFIK_HOST_STATIC "Enter the static wp domain name" static${INSTANCE_URL_SUFFIX}.${ROOT_DOMAIN} || true
+
 
 .PHONY: override-hook
 override-hook:
@@ -24,7 +33,7 @@ override-hook:
 ####                         # (this hardcodes the string into docker-compose.override.yaml)
 ####   name=@VARIABLE_NAME   # sets the template 'name' field to the literal string '${VARIABLE_NAME}'
 ####                         # (used for regular docker-compose expansion of env vars by name.)
-	@${BIN}/docker_compose_override ${ENV_FILE} project=:wp instance=@WP_INSTANCE traefik_host=@WP_TRAEFIK_HOST http_auth=WP_HTTP_AUTH http_auth_var=@WP_HTTP_AUTH ip_sourcerange=@WP_IP_SOURCERANGE enable_anti_hotlink=WP_ANTI_HOTLINK anti_hotlink_referers_extra=WP_ANTI_HOTLINK_REFERERS_EXTRA anti_hotlink_allow_empty_referer=WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER
+	@${BIN}/docker_compose_override ${ENV_FILE} project=:wp instance=@WP_INSTANCE traefik_host=@WP_TRAEFIK_HOST http_auth=WP_HTTP_AUTH http_auth_var=@WP_HTTP_AUTH ip_sourcerange=@WP_IP_SOURCERANGE enable_anti_hotlink=WP_ANTI_HOTLINK anti_hotlink_referers_extra=@WP_ANTI_HOTLINK_REFERERS_EXTRA anti_hotlink_allow_empty_referer=@WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER enable_wp2static=WP_WP2STATIC traefik_host_static=@WP_TRAEFIK_HOST_STATIC http_auth_static=WP_HTTP_AUTH_STATIC http_auth_static_var=@WP_HTTP_AUTH_STATIC ip_sourcerange_static=@WP_IP_SOURCERANGE_STATIC
 
 .PHONY: shell
 shell:

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,7 @@ override-hook:
 ####   name=@VARIABLE_NAME   # sets the template 'name' field to the literal string '${VARIABLE_NAME}'
 ####                         # (used for regular docker-compose expansion of env vars by name.)
 	@${BIN}/docker_compose_override ${ENV_FILE} project=:wp instance=@WP_INSTANCE traefik_host=@WP_TRAEFIK_HOST http_auth=WP_HTTP_AUTH http_auth_var=@WP_HTTP_AUTH ip_sourcerange=@WP_IP_SOURCERANGE enable_anti_hotlink=WP_ANTI_HOTLINK anti_hotlink_referers_extra=WP_ANTI_HOTLINK_REFERERS_EXTRA anti_hotlink_allow_empty_referer=WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER
+
+.PHONY: shell
+shell:
+	@docker-compose --env-file ${ENV_FILE} exec -it $${service:-wp} /bin/sh -c "/bin/bash || /bin/sh"

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ config-hook:
 	@${BIN}/reconfigure_ask ${ENV_FILE} WP_TRAEFIK_HOST "Enter the wp domain name" wp${INSTANCE_URL_SUFFIX}.${ROOT_DOMAIN}
 	@${BIN}/reconfigure_password ${ENV_FILE} WP_DB_ROOT_PASSWORD
 	@${BIN}/reconfigure_password ${ENV_FILE} WP_DB_PASSWORD
+	@${BIN}/confirm $$([[ $$(${BIN}/dotenv -f ${ENV_FILE} get WP_ANTI_HOTLINK) == "true" ]] && echo "yes" || echo "no") "Do you want to enable anti-hotlinking of images" "?" && ${BIN}/reconfigure ${ENV_FILE} WP_ANTI_HOTLINK=true || ${BIN}/reconfigure ${ENV_FILE} WP_ANTI_HOTLINK=false || true
+	[[ $$(${BIN}/dotenv -f ${ENV_FILE} get WP_ANTI_HOTLINK) == "true" ]] && ${BIN}/confirm $$([[ $$(${BIN}/dotenv -f ${ENV_FILE} get WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER) == "true" ]] && echo "yes" || echo "no") "Should a client that sends an empty referer be allowed to view attachments" "?" && ${BIN}/reconfigure ${ENV_FILE} WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER=true || ${BIN}/reconfigure ${ENV_FILE} WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER=false || true
 
 .PHONY: override-hook
 override-hook:
@@ -22,4 +24,4 @@ override-hook:
 ####                         # (this hardcodes the string into docker-compose.override.yaml)
 ####   name=@VARIABLE_NAME   # sets the template 'name' field to the literal string '${VARIABLE_NAME}'
 ####                         # (used for regular docker-compose expansion of env vars by name.)
-	@${BIN}/docker_compose_override ${ENV_FILE} project=:wp instance=@WP_INSTANCE traefik_host=@WP_TRAEFIK_HOST http_auth=WP_HTTP_AUTH http_auth_var=@WP_HTTP_AUTH ip_sourcerange=@WP_IP_SOURCERANGE
+	@${BIN}/docker_compose_override ${ENV_FILE} project=:wp instance=@WP_INSTANCE traefik_host=@WP_TRAEFIK_HOST http_auth=WP_HTTP_AUTH http_auth_var=@WP_HTTP_AUTH ip_sourcerange=@WP_IP_SOURCERANGE enable_anti_hotlink=WP_ANTI_HOTLINK anti_hotlink_referers_extra=WP_ANTI_HOTLINK_REFERERS_EXTRA anti_hotlink_allow_empty_referer=WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER

--- a/README.md
+++ b/README.md
@@ -8,16 +8,44 @@ d.rymcg allows you to easily self host many personal apps and services with trae
 - Follow the instructions at [d.rymcg.tech](https://github.com/EnigmaCurry/d.rymcg.tech).
 - Update the Makefile in this repo to point to the d.rymcg.tech repo ROOT on your system.
 - `make config`
+
+This will ask you some questions to generate the config. Here is a
+guide to the answers you should pick depending on which kind of
+deployment you want:
+
+ * Public Wordpress (default):
+  * Set `WP_TRAEFIK_HOST` to the domain name you want to use.
+  * Say `N` to the question about `HTTP Basic Authentication`.
+  * Say `Y` or `N` to enable `anti-hotlinking of images`.
+  * Allowing clients that send an empty referer is your choice.
+  * Say `N` to creating a static HTML wordpress export.
+
+ * Private Wordpress (more secure; with optional **public** HTML snapshot):
+  * Set `WP_TRAEFIK_HOST` to the domain name you want to use.
+  * Say `Y` to the question about `HTTP Basic Authentication`.
+  * Say `Y` or `N` to enable `anti-hotlinking of images` (applicable
+    to both private and/or public static websites).
+  * Say `N` or `Y` to creating a **public** static HTML wordpress export.
+
 - `make install`
 - `make status`
+- `make open`
+
+You must immediately configure the wordpress instance in your browser,
+setting the site title, and creating the admin account and password.
+Try to login (you might need to wait a minute). You should then be
+granted into the wordpress dashboard.
 
 ## Testing / Destroying
+
 - `make destroy` will delete everything in the instance
 - `make clean` will delete your configured .env and derived compose files.
 
 ## Anti-hotlinking
 
-To enable/disable hotlinking of uploaded images on other website domains, set the following variables in the `.env_{CONTEXT}` file:
+To enable/disable hotlinking of uploaded images on other website
+domains, answer the appropriate questions from `make config`, or set
+the following variables in the `.env_{CONTEXT}` file:
 
  * `WP_ANTI_HOTLINK=true` or `WP_ANTI_HOTLINK=false` to turn on/off
    the anti-hotlinking middleware. (Applies to the
@@ -29,3 +57,49 @@ To enable/disable hotlinking of uploaded images on other website domains, set th
    ability for clients that don't specify any referer to download the
    attachments (eg. RSS readers, curl, or copy/pasting the URL in the
    browser address bar).
+
+## Static HTML
+
+This config includes the ability to generate a static HTML snapshot of
+your wodpress site utilizing
+[wp2static](https://github.com/WP2Static/wp2static), and hosting it
+publicly with a static webserver (nginx). To enable the static
+website, answer the appropriate questions from `make config`, or set
+the following variables in the `.env_{CONTEXT}` file:
+
+ * `WP_WP2STATIC=true` or `WP_WP2STATIC=false` - to enable/disable the
+   static website.
+ * `WP_WP2STATIC_VERSION=7.2` - The version of wp2static you want to
+   use.
+ * `WP_TRAEFIK_HOST_STATIC` - the domain name for the static website.
+ * `WP_IP_SOURCERANGE_STATIC=0.0.0.0/0` - The IP whitelist for the static website.
+
+Once deployed, go to the wordpress dashboard to change settings and
+enable the plugin:
+
+ * Go to the `Settings` page, click `Permalinks`, choose any one of
+   the `Permalink structure` options *other than `Plain`*. (The `?` in
+   the Plain option is incompatible with the wp2static crawler, so you
+   must choose a different one.). Click `Save Changes`.
+ * Go to `Plugins` page, find the `WP2Static` plugin, and click on
+   `Activate`.
+ * Go to the `WP2Static` settings page (top left).
+ * Go to `Options`.
+ * Set the `Basic Auth User` and `Basic Auth Password` (Highly
+   recommended, but this should only be set *if* you enabled HTTP
+   Basic Auth during `make config`. Otherwise you should clear this
+   setting as your browser may have autofilled it with your wordpress
+   account name/password. Note: this should be the same username and
+   password saved in `passwords.json`, for the Traefik HTTP Basic
+   Authentication, not necessarily the same as your wordpress
+   account.).
+ * Set the `Deployment URL` to the same as `WP_TRAEFIK_HOST_STATIC`.
+ * Click `Save Options`.
+ * Go to `Run`.
+ * Click `Generate static site`.
+ * Click `Refresh Logs` several times until its finished.
+
+Now you can open the URL to your static website
+(`WP_TRAEFIK_HOST_STATIC`), and you should see a static snapshot of
+your wordpress site, the contents of which are stored in its own
+volume: `wp_wp2static`.

--- a/README.md
+++ b/README.md
@@ -14,18 +14,20 @@ guide to the answers you should pick depending on which kind of
 deployment you want:
 
  * Public Wordpress (default):
-  * Set `WP_TRAEFIK_HOST` to the domain name you want to use.
-  * Say `N` to the question about `HTTP Basic Authentication`.
-  * Say `Y` or `N` to enable `anti-hotlinking of images`.
-  * Allowing clients that send an empty referer is your choice.
-  * Say `N` to creating a static HTML wordpress export.
+
+   * Set `WP_TRAEFIK_HOST` to the domain name you want to use.
+   * Say `N` to the question about `HTTP Basic Authentication`.
+   * Say `Y` or `N` to enable `anti-hotlinking of images`.
+   * Allowing clients that send an empty referer is your choice.
+   * Say `N` to creating a static HTML wordpress export.
 
  * Private Wordpress (more secure; with optional **public** HTML snapshot):
-  * Set `WP_TRAEFIK_HOST` to the domain name you want to use.
-  * Say `Y` to the question about `HTTP Basic Authentication`.
-  * Say `Y` or `N` to enable `anti-hotlinking of images` (applicable
-    to both private and/or public static websites).
-  * Say `N` or `Y` to creating a **public** static HTML wordpress export.
+
+   * Set `WP_TRAEFIK_HOST` to the domain name you want to use.
+   * Say `Y` to the question about `HTTP Basic Authentication`.
+   * Say `Y` or `N` to enable `anti-hotlinking of images` (applicable
+     to both private and/or public static websites).
+   * Say `N` or `Y` to creating a **public** static HTML wordpress export.
 
 - `make install`
 - `make status`

--- a/README.md
+++ b/README.md
@@ -15,3 +15,17 @@ d.rymcg allows you to easily self host many personal apps and services with trae
 - `make destroy` will delete everything in the instance
 - `make clean` will delete your configured .env and derived compose files.
 
+## Anti-hotlinking
+
+To enable/disable hotlinking of uploaded images on other website domains, set the following variables in the `.env_{CONTEXT}` file:
+
+ * `WP_ANTI_HOTLINK=true` or `WP_ANTI_HOTLINK=false` to turn on/off
+   the anti-hotlinking middleware. (Applies to the
+   `/wp-content/upload` path only)
+ * `WP_ANTI_HOTLINK_REFERERS_EXTRA` is a comma separated list of
+   additional domain names to allow hotlinking from (whitelist).
+ * `WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER=true` or
+   `WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER=false` to turn on/off the
+   ability for clients that don't specify any referer to download the
+   attachments (eg. RSS readers, curl, or copy/pasting the URL in the
+   browser address bar).

--- a/docker-compose.instance.yaml
+++ b/docker-compose.instance.yaml
@@ -10,12 +10,17 @@
 #@ instance = data.values.instance
 #@ context = data.values.context
 #@ traefik_host = data.values.traefik_host
+#@ traefik_host_static = data.values.traefik_host_static
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
 #@ http_auth = data.values.http_auth_var
 #@ enable_anti_hotlink = data.values.enable_anti_hotlink == "true"
 #@ anti_hotlink_referers_extra = data.values.anti_hotlink_referers_extra
 #@ anti_hotlink_allow_empty_referer = data.values.anti_hotlink_allow_empty_referer
+#@ enable_wp2static = data.values.enable_wp2static == "true"
+#@ ip_sourcerange_static = data.values.ip_sourcerange_static
+#@ enable_http_auth_static = len(data.values.http_auth_static.strip()) > 0
+#@ http_auth_static = data.values.http_auth_static_var
 #@ enabled_middlewares = []
 
 #@yaml/text-templated-strings
@@ -83,3 +88,72 @@ services:
 
       #! Apply all middlewares (do this at the end!)
       - "traefik.http.routers.(@= attachments_router @).middlewares=(@= ','.join(enabled_middlewares) @)"
+
+  #@ if enable_wp2static:
+  wp-static:
+    build:
+      context: nginx-static
+    security_opt:
+      - no-new-privileges:true
+    volumes:
+      - wp_wp2static:/usr/share/nginx/html:ro
+    #@ service = "wp-static"
+    labels:
+      #! Services must opt-in to be proxied by Traefik:
+      - "traefik.enable=true"
+
+      #! 'router' is the fully qualified key in traefik for this router/service: project + instance + service
+      #@ router = "{}-{}-{}".format(project,instance,service)
+      #@ enabled_middlewares = []
+
+      #! The host matching router rule:
+      - "traefik.http.routers.(@= router @).rule=Host(`(@= traefik_host_static @)`)"
+      - "traefik.http.routers.(@= router @).entrypoints=websecure"
+      #@ enabled_middlewares.append("{}-ipwhitelist".format(router))
+      - "traefik.http.middlewares.(@= router @)-ipwhitelist.ipwhitelist.sourcerange=(@= ip_sourcerange_static @)"
+
+      #@ if enable_http_auth_static:
+      #@ enabled_middlewares.append("{}-basicauth".format(router))
+      - "traefik.http.middlewares.(@= router @)-basicauth.basicauth.users=(@= http_auth_static @)"
+      #@ end
+
+      #! Apply all middlewares (do this at the end!)
+      - "traefik.http.routers.(@= router @).middlewares=(@= ','.join(enabled_middlewares) @)"
+
+      #!###
+      #!###
+      #!###
+      #!###
+      #!### wp-content/upload attachments-router:
+      #! 'attachments_router' is the fully qualified key in traefik for this router/service: project + instance + service
+      #@ attachments_router = "{}-{}-{}-attachments".format(project,instance,service)
+      #@ enabled_middlewares = []
+
+      #! The host matching attachments-router rule:
+      - "traefik.http.routers.(@= attachments_router @).rule=Host(`(@= traefik_host_static @)`) && PathPrefix(`/wp-content/uploads`)"
+      - "traefik.http.routers.(@= attachments_router @).entrypoints=websecure"
+      #@ enabled_middlewares.append("{}-ipwhitelist".format(attachments_router))
+      - "traefik.http.middlewares.(@= attachments_router @)-ipwhitelist.ipwhitelist.sourcerange=(@= ip_sourcerange_static @)"
+
+      #@ if enable_http_auth_static:
+      #@ enabled_middlewares.append("{}-basicauth".format(attachments_router))
+      - "traefik.http.middlewares.(@= attachments_router @)-basicauth.basicauth.users=(@= http_auth_static @)"
+      #@ end
+
+      #@ if enable_anti_hotlink:
+      #@ enabled_middlewares.append("{}-referer-check".format(attachments_router))
+      - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.Type=white"
+      - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.EmptyReferer=(@= anti_hotlink_allow_empty_referer @)"
+      - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.Domains[0]=(@= traefik_host_static @)"
+      - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.Domains[1]=(@= traefik_host_static @):8443"
+      #@ referer_index = 1
+      #@ for extra_referer in anti_hotlink_referers_extra.strip().split(","):
+      #@ referer_index += 1
+      - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.Domains[(@= str(referer_index) @)]=(@= extra_referer @)"
+      #@ end
+      #@ end
+
+      #! Apply all middlewares (do this at the end!)
+      - "traefik.http.routers.(@= attachments_router @).middlewares=(@= ','.join(enabled_middlewares) @)"
+
+  #@ end

--- a/docker-compose.instance.yaml
+++ b/docker-compose.instance.yaml
@@ -23,6 +23,11 @@ services:
       #! Services must opt-in to be proxied by Traefik:
       - "traefik.enable=true"
 
+
+      #!###
+      #!###
+      #!### main router:
+      #!###
       #! 'router' is the fully qualified key in traefik for this router/service: project + instance + service
       #@ router = "{}-{}-{}".format(project,instance,service)
 
@@ -39,3 +44,31 @@ services:
 
       #! Apply all middlewares (do this at the end!)
       - "traefik.http.routers.(@= router @).middlewares=(@= ','.join(enabled_middlewares) @)"
+
+      #!###
+      #!###
+      #!###
+      #!###
+      #!### wp-content/upload attachments-router:
+      #! 'attachments_router' is the fully qualified key in traefik for this router/service: project + instance + service
+      #@ attachments_router = "{}-{}-{}-no-hotlink-attachments".format(project,instance,service)
+
+      #! The host matching attachments-router rule:
+      - "traefik.http.routers.(@= attachments_router @).rule=Host(`(@= traefik_host @)`) && PathPrefix(`/wp-content/uploads`)"
+      - "traefik.http.routers.(@= attachments_router @).entrypoints=websecure"
+      #@ enabled_middlewares.append("{}-ipwhitelist".format(attachments_router))
+      - "traefik.http.middlewares.(@= attachments_router @)-ipwhitelist.ipwhitelist.sourcerange=(@= ip_sourcerange @)"
+
+      #@ if enable_http_auth:
+      #@ enabled_middlewares.append("{}-basicauth".format(attachments_router))
+      - "traefik.http.middlewares.(@= attachments_router @)-basicauth.basicauth.users=(@= http_auth @)"
+      #@ end
+
+      #@ enabled_middlewares.append("{}-referer-check".format(attachments_router))
+      - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.Type=white"
+      - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.EmptyReferer=false"
+      - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.Domains[0]=(@= traefik_host @)"
+      - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.Domains[1]=(@= traefik_host @):8443"
+
+      #! Apply all middlewares (do this at the end!)
+      - "traefik.http.routers.(@= attachments_router @).middlewares=(@= ','.join(enabled_middlewares) @)"

--- a/docker-compose.instance.yaml
+++ b/docker-compose.instance.yaml
@@ -13,6 +13,9 @@
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
 #@ http_auth = data.values.http_auth_var
+#@ enable_anti_hotlink = data.values.enable_anti_hotlink == "true"
+#@ anti_hotlink_referers_extra = data.values.anti_hotlink_referers_extra
+#@ anti_hotlink_allow_empty_referer = data.values.anti_hotlink_allow_empty_referer
 #@ enabled_middlewares = []
 
 #@yaml/text-templated-strings
@@ -51,7 +54,8 @@ services:
       #!###
       #!### wp-content/upload attachments-router:
       #! 'attachments_router' is the fully qualified key in traefik for this router/service: project + instance + service
-      #@ attachments_router = "{}-{}-{}-no-hotlink-attachments".format(project,instance,service)
+      #@ attachments_router = "{}-{}-{}-attachments".format(project,instance,service)
+      #@ enabled_middlewares = []
 
       #! The host matching attachments-router rule:
       - "traefik.http.routers.(@= attachments_router @).rule=Host(`(@= traefik_host @)`) && PathPrefix(`/wp-content/uploads`)"
@@ -64,11 +68,18 @@ services:
       - "traefik.http.middlewares.(@= attachments_router @)-basicauth.basicauth.users=(@= http_auth @)"
       #@ end
 
+      #@ if enable_anti_hotlink:
       #@ enabled_middlewares.append("{}-referer-check".format(attachments_router))
       - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.Type=white"
-      - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.EmptyReferer=false"
+      - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.EmptyReferer=(@= anti_hotlink_allow_empty_referer @)"
       - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.Domains[0]=(@= traefik_host @)"
       - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.Domains[1]=(@= traefik_host @):8443"
+      #@ referer_index = 1
+      #@ for extra_referer in anti_hotlink_referers_extra.strip().split(","):
+      #@ referer_index += 1
+      - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.Domains[(@= str(referer_index) @)]=(@= extra_referer @)"
+      #@ end
+      #@ end
 
       #! Apply all middlewares (do this at the end!)
       - "traefik.http.routers.(@= attachments_router @).middlewares=(@= ','.join(enabled_middlewares) @)"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,15 +28,17 @@ services:
       - no-new-privileges:true
     volumes:
       - wp_data:/var/www/html
+      - wp_wp2static:/var/www/static
     restart: always
     environment:
       - WORDPRESS_DB_HOST=db
       - WORDPRESS_DB_USER=${WP_DB_USER}
       - WORDPRESS_DB_PASSWORD=${WP_DB_PASSWORD}
       - WORDPRESS_DB_NAME=${WP_DB_DATABASE}
-      # labels are defined in docker-compose.instance.yaml:
+    # labels are defined in docker-compose.instance.yaml:
     labels: []
 
 volumes:
   db_data:
   wp_data:
+  wp_wp2static:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,17 +17,17 @@ services:
       MARIADB_DATABASE: ${WP_DB_DATABASE}
       MARIADB_USER: ${WP_DB_USER}
       MARIADB_PASSWORD: ${WP_DB_PASSWORD}
-    expose:
-      - 3306
-      - 33060
+
   wp:
-    image: wordpress:${WP_VERSION}
+    build:
+      context: wordpress
+      args:
+        WORDPRESS_VERSION: ${WP_VERSION}
+        WP2STATIC_VERSION: ${WP_WP2STATIC_VERSION}
     security_opt:
       - no-new-privileges:true
     volumes:
       - wp_data:/var/www/html
-    # ports:
-    #   - 80:80
     restart: always
     environment:
       - WORDPRESS_DB_HOST=db
@@ -36,6 +36,7 @@ services:
       - WORDPRESS_DB_NAME=${WP_DB_DATABASE}
       # labels are defined in docker-compose.instance.yaml:
     labels: []
+
 volumes:
   db_data:
   wp_data:

--- a/nginx-static/Dockerfile
+++ b/nginx-static/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx
+RUN rm -rf /usr/share/nginx/html/* && \
+    chown -R www-data:www-data /usr/share/nginx/html
+VOLUME /usr/share/nginx/html

--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -1,0 +1,15 @@
+ARG WORDPRESS_VERSION
+FROM wordpress:${WORDPRESS_VERSION}
+ARG WP2STATIC_VERSION
+ADD install_composer.sh /tmp/install_composer.sh
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get -y install git
+RUN /tmp/install_composer.sh && \
+    rm /tmp/install_composer.sh && \
+    cd /var/www/html/wp-content/plugins && \
+    git clone https://github.com/wp2static/wp2static.git && \
+    cd wp2static && \
+    git checkout ${WP2STATIC_VERSION} && \
+    rm -rf .git && \
+    COMPOSER_ALLOW_SUPERUSER=1 composer install

--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -12,4 +12,11 @@ RUN /tmp/install_composer.sh && \
     cd wp2static && \
     git checkout ${WP2STATIC_VERSION} && \
     rm -rf .git && \
-    COMPOSER_ALLOW_SUPERUSER=1 composer install
+    COMPOSER_ALLOW_SUPERUSER=1 composer install && \
+    mkdir -p /var/www/html/wp-content/uploads /var/www/static && \
+    ln -s /var/www/static /var/www/html/wp-content/uploads/wp2static-processed-site && \
+    chown -R www-data:www-data /var/www/html /var/www/static
+VOLUME /var/www/html /var/www/static
+
+
+

--- a/wordpress/composer.json
+++ b/wordpress/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "monolog/monolog": "2.0.*"
+    }
+}

--- a/wordpress/install_composer.sh
+++ b/wordpress/install_composer.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+## https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
+
+EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]
+then
+    >&2 echo 'ERROR: Invalid installer checksum'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet
+RESULT=$?
+rm composer-setup.php
+mv composer.phar /usr/local/bin/composer
+exit $RESULT


### PR DESCRIPTION
This adds the [wp2static](https://github.com/WP2Static/wp2static) plugin and creates a static nginx webserver to host the static snapshot. The README includes instructions for how to configure for either a public or private instance and optional static export.

Fixes #4 

