### PR TITLE
Adds anti-hotlinking to the wp-content/upload URL path

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -15,3 +15,15 @@ TIMEZONE=America/New_York
 ##Allow all access: 0.0.0.0/0
 WP_IP_SOURCERANGE=0.0.0.0/0
 WP_HTTP_AUTH=
+
+## Enable anti-hotlinking of images (or not):
+WP_ANTI_HOTLINK=true
+
+## Extra URLs besides WP_TRAEFIK_HOST to allow hotlinking from:
+## Specify multiple domains separated by commas.
+## (Wildcard domains allowed. Must include port number if not 80/443)
+WP_ANTI_HOTLINK_REFERERS_EXTRA=
+
+## Should clients that *don't* specify the referer be allowed to hotlink?
+## (eg. RSS readers, curl, or copy and pasting into the browser URL bar.)
+WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER=true

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ config-hook:
 	@${BIN}/reconfigure_ask ${ENV_FILE} WP_TRAEFIK_HOST "Enter the wp domain name" wp${INSTANCE_URL_SUFFIX}.${ROOT_DOMAIN}
 	@${BIN}/reconfigure_password ${ENV_FILE} WP_DB_ROOT_PASSWORD
 	@${BIN}/reconfigure_password ${ENV_FILE} WP_DB_PASSWORD
+	@${BIN}/confirm $$([[ $$(${BIN}/dotenv -f ${ENV_FILE} get WP_ANTI_HOTLINK) == "true" ]] && echo "yes" || echo "no") "Do you want to enable anti-hotlinking of images" "?" && ${BIN}/reconfigure ${ENV_FILE} WP_ANTI_HOTLINK=true || ${BIN}/reconfigure ${ENV_FILE} WP_ANTI_HOTLINK=false || true
+	[[ $$(${BIN}/dotenv -f ${ENV_FILE} get WP_ANTI_HOTLINK) == "true" ]] && ${BIN}/confirm $$([[ $$(${BIN}/dotenv -f ${ENV_FILE} get WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER) == "true" ]] && echo "yes" || echo "no") "Should a client that sends an empty referer be allowed to view attachments" "?" && ${BIN}/reconfigure ${ENV_FILE} WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER=true || ${BIN}/reconfigure ${ENV_FILE} WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER=false || true
 
 .PHONY: override-hook
 override-hook:
@@ -22,4 +24,4 @@ override-hook:
 ####                         # (this hardcodes the string into docker-compose.override.yaml)
 ####   name=@VARIABLE_NAME   # sets the template 'name' field to the literal string '${VARIABLE_NAME}'
 ####                         # (used for regular docker-compose expansion of env vars by name.)
-	@${BIN}/docker_compose_override ${ENV_FILE} project=:wp instance=@WP_INSTANCE traefik_host=@WP_TRAEFIK_HOST http_auth=WP_HTTP_AUTH http_auth_var=@WP_HTTP_AUTH ip_sourcerange=@WP_IP_SOURCERANGE
+	@${BIN}/docker_compose_override ${ENV_FILE} project=:wp instance=@WP_INSTANCE traefik_host=@WP_TRAEFIK_HOST http_auth=WP_HTTP_AUTH http_auth_var=@WP_HTTP_AUTH ip_sourcerange=@WP_IP_SOURCERANGE enable_anti_hotlink=WP_ANTI_HOTLINK anti_hotlink_referers_extra=WP_ANTI_HOTLINK_REFERERS_EXTRA anti_hotlink_allow_empty_referer=WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER

--- a/README.md
+++ b/README.md
@@ -15,3 +15,17 @@ d.rymcg allows you to easily self host many personal apps and services with trae
 - `make destroy` will delete everything in the instance
 - `make clean` will delete your configured .env and derived compose files.
 
+## Anti-hotlinking
+
+To enable/disable hotlinking of uploaded images on other website domains, set the following variables in the `.env_{CONTEXT}` file:
+
+ * `WP_ANTI_HOTLINK=true` or `WP_ANTI_HOTLINK=false` to turn on/off
+   the anti-hotlinking middleware. (Applies to the
+   `/wp-content/upload` path only)
+ * `WP_ANTI_HOTLINK_REFERERS_EXTRA` is a comma separated list of
+   additional domain names to allow hotlinking from (whitelist).
+ * `WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER=true` or
+   `WP_ANTI_HOTLINK_ALLOW_EMPTY_REFERER=false` to turn on/off the
+   ability for clients that don't specify any referer to download the
+   attachments (eg. RSS readers, curl, or copy/pasting the URL in the
+   browser address bar).

--- a/docker-compose.instance.yaml
+++ b/docker-compose.instance.yaml
@@ -23,6 +23,11 @@ services:
       #! Services must opt-in to be proxied by Traefik:
       - "traefik.enable=true"
 
+
+      #!###
+      #!###
+      #!### main router:
+      #!###
       #! 'router' is the fully qualified key in traefik for this router/service: project + instance + service
       #@ router = "{}-{}-{}".format(project,instance,service)
 
@@ -39,3 +44,31 @@ services:
 
       #! Apply all middlewares (do this at the end!)
       - "traefik.http.routers.(@= router @).middlewares=(@= ','.join(enabled_middlewares) @)"
+
+      #!###
+      #!###
+      #!###
+      #!###
+      #!### wp-content/upload attachments-router:
+      #! 'attachments_router' is the fully qualified key in traefik for this router/service: project + instance + service
+      #@ attachments_router = "{}-{}-{}-no-hotlink-attachments".format(project,instance,service)
+
+      #! The host matching attachments-router rule:
+      - "traefik.http.routers.(@= attachments_router @).rule=Host(`(@= traefik_host @)`) && PathPrefix(`/wp-content/uploads`)"
+      - "traefik.http.routers.(@= attachments_router @).entrypoints=websecure"
+      #@ enabled_middlewares.append("{}-ipwhitelist".format(attachments_router))
+      - "traefik.http.middlewares.(@= attachments_router @)-ipwhitelist.ipwhitelist.sourcerange=(@= ip_sourcerange @)"
+
+      #@ if enable_http_auth:
+      #@ enabled_middlewares.append("{}-basicauth".format(attachments_router))
+      - "traefik.http.middlewares.(@= attachments_router @)-basicauth.basicauth.users=(@= http_auth @)"
+      #@ end
+
+      #@ enabled_middlewares.append("{}-referer-check".format(attachments_router))
+      - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.Type=white"
+      - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.EmptyReferer=false"
+      - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.Domains[0]=(@= traefik_host @)"
+      - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.Domains[1]=(@= traefik_host @):8443"
+
+      #! Apply all middlewares (do this at the end!)
+      - "traefik.http.routers.(@= attachments_router @).middlewares=(@= ','.join(enabled_middlewares) @)"

--- a/docker-compose.instance.yaml
+++ b/docker-compose.instance.yaml
@@ -13,6 +13,9 @@
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
 #@ http_auth = data.values.http_auth_var
+#@ enable_anti_hotlink = data.values.enable_anti_hotlink == "true"
+#@ anti_hotlink_referers_extra = data.values.anti_hotlink_referers_extra
+#@ anti_hotlink_allow_empty_referer = data.values.anti_hotlink_allow_empty_referer
 #@ enabled_middlewares = []
 
 #@yaml/text-templated-strings
@@ -51,7 +54,8 @@ services:
       #!###
       #!### wp-content/upload attachments-router:
       #! 'attachments_router' is the fully qualified key in traefik for this router/service: project + instance + service
-      #@ attachments_router = "{}-{}-{}-no-hotlink-attachments".format(project,instance,service)
+      #@ attachments_router = "{}-{}-{}-attachments".format(project,instance,service)
+      #@ enabled_middlewares = []
 
       #! The host matching attachments-router rule:
       - "traefik.http.routers.(@= attachments_router @).rule=Host(`(@= traefik_host @)`) && PathPrefix(`/wp-content/uploads`)"
@@ -64,11 +68,18 @@ services:
       - "traefik.http.middlewares.(@= attachments_router @)-basicauth.basicauth.users=(@= http_auth @)"
       #@ end
 
+      #@ if enable_anti_hotlink:
       #@ enabled_middlewares.append("{}-referer-check".format(attachments_router))
       - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.Type=white"
-      - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.EmptyReferer=false"
+      - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.EmptyReferer=(@= anti_hotlink_allow_empty_referer @)"
       - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.Domains[0]=(@= traefik_host @)"
       - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.Domains[1]=(@= traefik_host @):8443"
+      #@ referer_index = 1
+      #@ for extra_referer in anti_hotlink_referers_extra.strip().split(","):
+      #@ referer_index += 1
+      - "traefik.http.middlewares.(@= attachments_router @)-referer-check.plugin.referer.Domains[(@= str(referer_index) @)]=(@= extra_referer @)"
+      #@ end
+      #@ end
 
       #! Apply all middlewares (do this at the end!)
       - "traefik.http.routers.(@= attachments_router @).middlewares=(@= ','.join(enabled_middlewares) @)"


### PR DESCRIPTION
This disables hotlinking of images. This forbids any loading unless the referer is the instance URL. EmptyReferer=false even forbids it if there is no referer (ie. curl).